### PR TITLE
Implement tracelog

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -64,7 +64,7 @@ type disjointConstraintFailure struct {
 func (e *disjointConstraintFailure) Error() string {
 	if len(e.failsib) == 1 {
 		str := "Could not introduce %s at %s, as it has a dependency on %s with constraint %s, which has no overlap with existing constraint %s from %s at %s"
-		return fmt.Sprintf(str, e.goal.Depender.Ident, e.goal.Depender.Version, e.goal.Dep.Ident.errString(), e.goal.Dep.Constraint.String(), e.failsib[0].Dep.Constraint.String(), e.failsib[0].Depender.Ident, e.failsib[0].Depender.Version)
+		return fmt.Sprintf(str, e.goal.Depender.Ident.errString(), e.goal.Depender.Version, e.goal.Dep.Ident.errString(), e.goal.Dep.Constraint.String(), e.failsib[0].Dep.Constraint.String(), e.failsib[0].Depender.Ident.errString(), e.failsib[0].Depender.Version)
 	}
 
 	var buf bytes.Buffer
@@ -74,16 +74,16 @@ func (e *disjointConstraintFailure) Error() string {
 		sibs = e.failsib
 
 		str := "Could not introduce %s at %s, as it has a dependency on %s with constraint %s, which has no overlap with the following existing constraints:\n"
-		fmt.Fprintf(&buf, str, e.goal.Depender.Ident, e.goal.Depender.Version, e.goal.Dep.Ident.errString(), e.goal.Dep.Constraint.String())
+		fmt.Fprintf(&buf, str, e.goal.Depender.Ident.errString(), e.goal.Depender.Version, e.goal.Dep.Ident.errString(), e.goal.Dep.Constraint.String())
 	} else {
 		sibs = e.nofailsib
 
 		str := "Could not introduce %s at %s, as it has a dependency on %s with constraint %s, which does not overlap with the intersection of existing constraints from other currently selected packages:\n"
-		fmt.Fprintf(&buf, str, e.goal.Depender.Ident, e.goal.Depender.Version, e.goal.Dep.Ident.errString(), e.goal.Dep.Constraint.String())
+		fmt.Fprintf(&buf, str, e.goal.Depender.Ident.errString(), e.goal.Depender.Version, e.goal.Dep.Ident.errString(), e.goal.Dep.Constraint.String())
 	}
 
 	for _, c := range sibs {
-		fmt.Fprintf(&buf, "\t%s at %s with constraint %s\n", c.Depender.Ident, c.Depender.Version, c.Dep.Constraint.String())
+		fmt.Fprintf(&buf, "\t%s from %s at %s\n", c.Dep.Constraint.String(), c.Depender.Ident.errString(), c.Depender.Version)
 	}
 
 	return buf.String()
@@ -111,16 +111,16 @@ type versionNotAllowedFailure struct {
 func (e *versionNotAllowedFailure) Error() string {
 	if len(e.failparent) == 1 {
 		str := "Could not introduce %s at %s, as it is not allowed by constraint %s from project %s."
-		return fmt.Sprintf(str, e.goal.Ident, e.goal.Version, e.failparent[0].Dep.Constraint.String(), e.failparent[0].Depender.Ident)
+		return fmt.Sprintf(str, e.goal.Ident.errString(), e.goal.Version, e.failparent[0].Dep.Constraint.String(), e.failparent[0].Depender.Ident.errString())
 	}
 
 	var buf bytes.Buffer
 
 	str := "Could not introduce %s at %s, as it is not allowed by constraints from the following projects:\n"
-	fmt.Fprintf(&buf, str, e.goal.Ident, e.goal.Version)
+	fmt.Fprintf(&buf, str, e.goal.Ident.errString(), e.goal.Version)
 
 	for _, f := range e.failparent {
-		fmt.Fprintf(&buf, "\t%s at %s with constraint %s\n", f.Depender.Ident, f.Depender.Version, f.Dep.Constraint.String())
+		fmt.Fprintf(&buf, "\t%s from %s at %s\n", f.Dep.Constraint.String(), f.Depender.Ident.errString(), f.Depender.Version)
 	}
 
 	return buf.String()

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: f3bcd8dbd2ab556604fb9b7a2b67335e5a07259580801ffc15808590889802a1
-updated: 2016-04-14T22:30:56.806524724-04:00
+hash: 6bd3b42b8d3ffd99e2ed2c4b75b1a6f9f1a96ea78714fe5b59f7333b8056656a
+updated: 2016-05-04T00:16:45.75684042-04:00
 imports:
 - name: github.com/Masterminds/semver
   version: 0a2c9fc0eee2c4cbb9526877c4a54da047fdcadd
@@ -7,12 +7,7 @@ imports:
 - name: github.com/Masterminds/vcs
   version: 7a21de0acff824ccf45f633cc844a19625149c2f
   vcs: git
-- name: github.com/Sirupsen/logrus
-  version: 4b6ea7319e214d98c938f12692336f7ca9348d6b
 - name: github.com/termie/go-shutil
   version: bcacb06fecaeec8dc42af03c87c6949f4a05c74c
-- name: golang.org/x/sys
-  version: b323466d0bc6669362b0836480b30452d2c00db9
-  subpackages:
-  - unix
+  vcs: git
 devImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -4,10 +4,6 @@ import:
   version: 2.x
   vtype: branch
   vcs: git
-- package: github.com/Sirupsen/logrus
-  version: 0.10.0
-  vtype: semver
-  vcs: git
 - package: github.com/Masterminds/vcs
   vcs: git
 - package: github.com/termie/go-shutil

--- a/satisfy.go
+++ b/satisfy.go
@@ -180,7 +180,8 @@ func (s *solver) checkDepsDisallowsSelected(pa ProjectAtom, dep ProjectDep) erro
 // been selected).
 //
 // In other words, this ensures that the solver never simultaneously selects two
-// identifiers that disagree about where their upstream source is.
+// identifiers with the same local name, but that disagree about where their
+// network source is.
 func (s *solver) checkIdentMatches(pa ProjectAtom, dep ProjectDep) error {
 	if cur, exists := s.names[dep.Ident.LocalName]; exists {
 		if cur != dep.Ident.netName() {

--- a/satisfy.go
+++ b/satisfy.go
@@ -1,7 +1,5 @@
 package vsolver
 
-import "github.com/Sirupsen/logrus"
-
 // satisfiable is the main checking method. It determines if introducing a new
 // project atom would result in a state where all solver requirements are still
 // satisfied.
@@ -10,13 +8,6 @@ func (s *solver) satisfiable(pa ProjectAtom) error {
 		// TODO we should protect against this case elsewhere, but for now panic
 		// to canary when it's a problem
 		panic("canary - checking version of empty ProjectAtom")
-	}
-
-	if s.l.Level >= logrus.DebugLevel {
-		s.l.WithFields(logrus.Fields{
-			"name":    pa.Ident,
-			"version": pa.Version,
-		}).Debug("Checking satisfiability of project atom against current constraints")
 	}
 
 	if err := s.checkAtomAllowable(pa); err != nil {
@@ -43,13 +34,6 @@ func (s *solver) satisfiable(pa ProjectAtom) error {
 		// TODO add check that fails if adding this atom would create a loop
 	}
 
-	if s.l.Level >= logrus.DebugLevel {
-		s.l.WithFields(logrus.Fields{
-			"name":    pa.Ident,
-			"version": pa.Version,
-		}).Debug("Project atom passed satisfiability test against current state")
-	}
-
 	return nil
 }
 
@@ -62,25 +46,10 @@ func (s *solver) checkAtomAllowable(pa ProjectAtom) error {
 	}
 	// TODO collect constraint failure reason
 
-	if s.l.Level >= logrus.InfoLevel {
-		s.l.WithFields(logrus.Fields{
-			"name":          pa.Ident,
-			"version":       pa.Version,
-			"curconstraint": constraint.String(),
-		}).Info("Current constraints do not allow version")
-	}
-
 	deps := s.sel.getDependenciesOn(pa.Ident)
 	var failparent []Dependency
 	for _, dep := range deps {
 		if !dep.Dep.Constraint.Matches(pa.Version) {
-			if s.l.Level >= logrus.DebugLevel {
-				s.l.WithFields(logrus.Fields{
-					"name":       pa.Ident,
-					"othername":  dep.Depender.Ident,
-					"constraint": dep.Dep.Constraint.String(),
-				}).Debug("Marking other, selected project with conflicting constraint as failed")
-			}
 			s.fail(dep.Depender.Ident)
 			failparent = append(failparent, dep)
 		}
@@ -106,31 +75,12 @@ func (s *solver) checkDepsConstraintsAllowable(pa ProjectAtom, dep ProjectDep) e
 		return nil
 	}
 
-	if s.l.Level >= logrus.DebugLevel {
-		s.l.WithFields(logrus.Fields{
-			"name":          pa.Ident,
-			"version":       pa.Version,
-			"depname":       dep.Ident,
-			"curconstraint": constraint.String(),
-			"newconstraint": dep.Constraint.String(),
-		}).Debug("Project atom cannot be added; its constraints are disjoint with existing constraints")
-	}
-
 	siblings := s.sel.getDependenciesOn(dep.Ident)
 	// No admissible versions - visit all siblings and identify the disagreement(s)
 	var failsib []Dependency
 	var nofailsib []Dependency
 	for _, sibling := range siblings {
 		if !sibling.Dep.Constraint.MatchesAny(dep.Constraint) {
-			if s.l.Level >= logrus.DebugLevel {
-				s.l.WithFields(logrus.Fields{
-					"name":          pa.Ident,
-					"version":       pa.Version,
-					"depname":       sibling.Depender.Ident,
-					"sibconstraint": sibling.Dep.Constraint.String(),
-					"newconstraint": dep.Constraint.String(),
-				}).Debug("Marking other, selected project as failed because its constraint is disjoint with our testee")
-			}
 			s.fail(sibling.Depender.Ident)
 			failsib = append(failsib, sibling)
 		} else {
@@ -154,15 +104,6 @@ func (s *solver) checkDepsConstraintsAllowable(pa ProjectAtom, dep ProjectDep) e
 func (s *solver) checkDepsDisallowsSelected(pa ProjectAtom, dep ProjectDep) error {
 	selected, exists := s.sel.selected(dep.Ident)
 	if exists && !dep.Constraint.Matches(selected.Version) {
-		if s.l.Level >= logrus.DebugLevel {
-			s.l.WithFields(logrus.Fields{
-				"name":          pa.Ident,
-				"version":       pa.Version,
-				"depname":       dep.Ident,
-				"curversion":    selected.Version,
-				"newconstraint": dep.Constraint.String(),
-			}).Debug("Project atom cannot be added; a constraint it introduces does not allow a currently selected version")
-		}
 		s.fail(dep.Ident)
 
 		err := &constraintNotAllowedFailure{

--- a/solve_test.go
+++ b/solve_test.go
@@ -6,8 +6,6 @@ import (
 	"os"
 	"strings"
 	"testing"
-
-	"github.com/Sirupsen/logrus"
 )
 
 // TODO regression test ensuring that locks with only revs for projects don't cause errors
@@ -37,16 +35,11 @@ func solveAndBasicChecks(fix fixture, t *testing.T) (res Result, err error) {
 		ChangeAll: fix.changeall,
 	}
 
-	l := logrus.New()
 	if testing.Verbose() {
-		//l.Level = logrus.DebugLevel
-		l.Level = logrus.WarnLevel
 		o.Trace = true
-	} else {
-		l.Level = logrus.WarnLevel
 	}
 
-	s := NewSolver(sm, l, stderrlog)
+	s := NewSolver(sm, stderrlog)
 
 	if fix.l != nil {
 		o.L = fix.l
@@ -180,12 +173,7 @@ func getFailureCausingProjects(err error) (projs []string) {
 func TestBadSolveOpts(t *testing.T) {
 	sm := newdepspecSM(fixtures[0].ds)
 
-	l := logrus.New()
-	if testing.Verbose() {
-		l.Level = logrus.DebugLevel
-	}
-
-	s := NewSolver(sm, l, nil)
+	s := NewSolver(sm, nil)
 
 	o := SolveOpts{}
 	_, err := s.Solve(o)

--- a/solve_test.go
+++ b/solve_test.go
@@ -2,6 +2,8 @@ package vsolver
 
 import (
 	"fmt"
+	"log"
+	"os"
 	"strings"
 	"testing"
 
@@ -20,15 +22,6 @@ func TestBasicSolves(t *testing.T) {
 func solveAndBasicChecks(fix fixture, t *testing.T) (res Result, err error) {
 	sm := newdepspecSM(fix.ds)
 
-	l := logrus.New()
-	if testing.Verbose() {
-		l.Level = logrus.DebugLevel
-	} else {
-		l.Level = logrus.WarnLevel
-	}
-
-	s := NewSolver(sm, l)
-
 	o := SolveOpts{
 		Root:      string(fix.ds[0].Name()),
 		N:         ProjectName(fix.ds[0].Name()),
@@ -37,6 +30,17 @@ func solveAndBasicChecks(fix fixture, t *testing.T) (res Result, err error) {
 		Downgrade: fix.downgrade,
 		ChangeAll: fix.changeall,
 	}
+
+	l := logrus.New()
+	if testing.Verbose() {
+		//l.Level = logrus.DebugLevel
+		l.Level = logrus.WarnLevel
+		o.Trace = true
+	} else {
+		l.Level = logrus.WarnLevel
+	}
+
+	s := NewSolver(sm, l, log.New(os.Stderr, "", 0))
 
 	if fix.l != nil {
 		o.L = fix.l
@@ -175,7 +179,7 @@ func TestBadSolveOpts(t *testing.T) {
 		l.Level = logrus.DebugLevel
 	}
 
-	s := NewSolver(sm, l)
+	s := NewSolver(sm, l, nil)
 
 	o := SolveOpts{}
 	_, err := s.Solve(o)

--- a/solve_test.go
+++ b/solve_test.go
@@ -12,10 +12,16 @@ import (
 
 // TODO regression test ensuring that locks with only revs for projects don't cause errors
 
+var stderrlog = log.New(os.Stderr, "", 0)
+
 func TestBasicSolves(t *testing.T) {
 	//solveAndBasicChecks(fixtures[8], t)
 	for _, fix := range fixtures {
 		solveAndBasicChecks(fix, t)
+		if testing.Verbose() {
+			// insert a line break between tests
+			stderrlog.Println("")
+		}
 	}
 }
 
@@ -40,7 +46,7 @@ func solveAndBasicChecks(fix fixture, t *testing.T) (res Result, err error) {
 		l.Level = logrus.WarnLevel
 	}
 
-	s := NewSolver(sm, l, log.New(os.Stderr, "", 0))
+	s := NewSolver(sm, l, stderrlog)
 
 	if fix.l != nil {
 		o.L = fix.l

--- a/solver.go
+++ b/solver.go
@@ -575,7 +575,7 @@ func (s *solver) backtrack() bool {
 			}
 		}
 
-		s.logSolve("no more versions of %s, backtracking")
+		s.logSolve("no more versions of %s, backtracking", q.id.errString())
 		if s.l.Level >= logrus.DebugLevel {
 			s.l.WithFields(logrus.Fields{
 				"name": q.id.errString(),


### PR DESCRIPTION
per #5 and #15 

still need to write up an alternate version of string generation for the error types that we pass in. what's done now is just too verbose for inclusion in trace tree output, but it's good when it's the final error, so we need an alternate path.