### PR TITLE
Allow matching/equivalency across versions with shared underlying revisions

### DIFF
--- a/constraint_test.go
+++ b/constraint_test.go
@@ -555,6 +555,24 @@ func TestSemverVersionConstraintOps(t *testing.T) {
 	if v6.Intersect(o4) != cookie {
 		t.Errorf("Intersection of %s (semver) with %s (branch) should return shared underlying rev", gu(v6), gu(o4))
 	}
+
+	// Regression check - make sure that semVersion -> semverConstraint works
+	// the same as verified in the other test
+	c1, _ := NewConstraint("=1.0.0", SemverConstraint)
+	if !v1.MatchesAny(c1) {
+		t.Errorf("%s (semver) should allow some matches - itself - when combined with an equivalent semverConstraint", gu(v1))
+	}
+	if v1.Intersect(c1) != v1 {
+		t.Errorf("Intersection of %s (semver) with equivalent semver constraint should return self, got %s", gu(v1), v1.Intersect(c1))
+	}
+
+	if !v6.MatchesAny(c1) {
+		t.Errorf("%s (semver pair) should allow some matches - itself - when combined with an equivalent semverConstraint", gu(v6))
+	}
+	if v6.Intersect(c1) != v6 {
+		t.Errorf("Intersection of %s (semver pair) with equivalent semver constraint should return self, got %s", gu(v6), v6.Intersect(c1))
+	}
+
 }
 
 // The other test is about the semverVersion, this is about semverConstraint

--- a/constraint_test.go
+++ b/constraint_test.go
@@ -671,3 +671,147 @@ func TestSemverConstraintOps(t *testing.T) {
 		t.Errorf("Semver constraint should return input when intersected with a paired semver version in its range")
 	}
 }
+
+// Test that certain types of cross-version comparisons work when they are
+// expressed as a version union (but that others don't).
+func TestVersionUnion(t *testing.T) {
+	rev := Revision("flooboofoobooo")
+	v1 := NewBranch("master")
+	v2 := NewBranch("test")
+	v3 := NewVersion("1.0.0").Is(rev)
+	v4 := NewVersion("1.0.1")
+	v5 := NewVersion("v2.0.5").Is(Revision("notamatch"))
+
+	uv1 := versionTypeUnion{v1, v4, rev}
+
+	if uv1.MatchesAny(none) {
+		t.Errorf("Union can't match none")
+	}
+	if none.MatchesAny(uv1) {
+		t.Errorf("Union can't match none")
+	}
+
+	if !uv1.MatchesAny(any) {
+		t.Errorf("Union must match any")
+	}
+	if !any.MatchesAny(uv1) {
+		t.Errorf("Union must match any")
+	}
+
+	// Basic matching
+	if !uv1.Matches(v4) {
+		t.Errorf("Union should match on branch to branch")
+	}
+	if !v4.Matches(uv1) {
+		t.Errorf("Union should reverse-match on branch to branch")
+	}
+
+	if !uv1.Matches(v3) {
+		t.Errorf("Union should match on rev to paired rev")
+	}
+	if !v3.Matches(uv1) {
+		t.Errorf("Union should reverse-match on rev to paired rev")
+	}
+
+	if uv1.Matches(v2) {
+		t.Errorf("Union should not match on anything in disjoint unpaired")
+	}
+	if v2.Matches(uv1) {
+		t.Errorf("Union should not reverse-match on anything in disjoint unpaired")
+	}
+
+	if uv1.Matches(v5) {
+		t.Errorf("Union should not match on anything in disjoint pair")
+	}
+	if v5.Matches(uv1) {
+		t.Errorf("Union should not reverse-match on anything in disjoint pair")
+	}
+
+	// MatchesAny - repeat Matches for safety, but add more, too
+	if !uv1.MatchesAny(v4) {
+		t.Errorf("Union should match on branch to branch")
+	}
+	if !v4.MatchesAny(uv1) {
+		t.Errorf("Union should reverse-match on branch to branch")
+	}
+
+	if !uv1.MatchesAny(v3) {
+		t.Errorf("Union should match on rev to paired rev")
+	}
+	if !v3.MatchesAny(uv1) {
+		t.Errorf("Union should reverse-match on rev to paired rev")
+	}
+
+	if uv1.MatchesAny(v2) {
+		t.Errorf("Union should not match on anything in disjoint unpaired")
+	}
+	if v2.MatchesAny(uv1) {
+		t.Errorf("Union should not reverse-match on anything in disjoint unpaired")
+	}
+
+	if uv1.MatchesAny(v5) {
+		t.Errorf("Union should not match on anything in disjoint pair")
+	}
+	if v5.MatchesAny(uv1) {
+		t.Errorf("Union should not reverse-match on anything in disjoint pair")
+	}
+
+	c1, _ := NewConstraint("~1.0.0", SemverConstraint)
+	c2, _ := NewConstraint("~2.0.0", SemverConstraint)
+	if !uv1.MatchesAny(c1) {
+		t.Errorf("Union should have some overlap due to containing 1.0.1 version")
+	}
+	if !c1.MatchesAny(uv1) {
+		t.Errorf("Union should have some overlap due to containing 1.0.1 version")
+	}
+
+	if uv1.MatchesAny(c2) {
+		t.Errorf("Union should have no overlap with ~2.0.0 semver range")
+	}
+	if c2.MatchesAny(uv1) {
+		t.Errorf("Union should have no overlap with ~2.0.0 semver range")
+	}
+
+	// Intersect - repeat all previous
+	if uv1.Intersect(v4) != v4 {
+		t.Errorf("Union intersection on contained version should return that version")
+	}
+	if v4.Intersect(uv1) != v4 {
+		t.Errorf("Union reverse-intersection on contained version should return that version")
+	}
+
+	if uv1.Intersect(v3) != rev {
+		t.Errorf("Union intersection on paired version w/matching rev should return rev, got %s", uv1.Intersect(v3))
+	}
+	if v3.Intersect(uv1) != rev {
+		t.Errorf("Union reverse-intersection on paired version w/matching rev should return rev, got %s", v3.Intersect(uv1))
+	}
+
+	if uv1.Intersect(v2) != none {
+		t.Errorf("Union should not intersect with anything in disjoint unpaired")
+	}
+	if v2.Intersect(uv1) != none {
+		t.Errorf("Union should not reverse-intersect with anything in disjoint unpaired")
+	}
+
+	if uv1.Intersect(v5) != none {
+		t.Errorf("Union should not intersect with anything in disjoint pair")
+	}
+	if v5.Intersect(uv1) != none {
+		t.Errorf("Union should not reverse-intersect with anything in disjoint pair")
+	}
+
+	if uv1.Intersect(c1) != v4 {
+		t.Errorf("Union intersecting with semver range should return 1.0.1 version, got %s", uv1.Intersect(c1))
+	}
+	if c1.Intersect(uv1) != v4 {
+		t.Errorf("Union reverse-intersecting with semver range should return 1.0.1 version, got %s", c1.Intersect(uv1))
+	}
+
+	if uv1.Intersect(c2) != none {
+		t.Errorf("Union intersecting with non-overlapping semver range should return none, got %s", uv1.Intersect(c2))
+	}
+	if c2.Intersect(uv1) != none {
+		t.Errorf("Union reverse-intersecting with non-overlapping semver range should return none, got %s", uv1.Intersect(c2))
+	}
+}

--- a/constraints.go
+++ b/constraints.go
@@ -67,6 +67,12 @@ func (c semverConstraint) String() string {
 
 func (c semverConstraint) Matches(v Version) bool {
 	switch tv := v.(type) {
+	case versionTypeUnion:
+		for _, elem := range tv {
+			if c.Matches(elem) {
+				return true
+			}
+		}
 	case semVersion:
 		return c.c.Matches(tv.sv) == nil
 	case versionPair:
@@ -86,6 +92,12 @@ func (c semverConstraint) Intersect(c2 Constraint) Constraint {
 	switch tc := c2.(type) {
 	case anyConstraint:
 		return c
+	case versionTypeUnion:
+		for _, elem := range tc {
+			if rc := c.Intersect(elem); rc != none {
+				return rc
+			}
+		}
 	case semverConstraint:
 		rc := c.c.Intersect(tc.c)
 		if !semver.IsNone(rc) {

--- a/manager_test.go
+++ b/manager_test.go
@@ -64,6 +64,11 @@ func TestSourceManagerInit(t *testing.T) {
 }
 
 func TestProjectManagerInit(t *testing.T) {
+	// This test is a bit slow, skip it on -short
+	if testing.Short() {
+		t.Skip("Skipping project manager init test in short mode")
+	}
+
 	cpath, err := ioutil.TempDir("", "smcache")
 	if err != nil {
 		t.Errorf("Failed to create temp dir: %s", err)
@@ -177,6 +182,11 @@ func TestProjectManagerInit(t *testing.T) {
 }
 
 func TestRepoVersionFetching(t *testing.T) {
+	// This test is quite slow, skip it on -short
+	if testing.Short() {
+		t.Skip("Skipping repo version fetching test in short mode")
+	}
+
 	cpath, err := ioutil.TempDir("", "smcache")
 	if err != nil {
 		t.Errorf("Failed to create temp dir: %s", err)

--- a/result_test.go
+++ b/result_test.go
@@ -48,6 +48,11 @@ func init() {
 }
 
 func TestResultCreateVendorTree(t *testing.T) {
+	// This test is a bit slow, skip it on -short
+	if testing.Short() {
+		t.Skip("Skipping vendor tree creation test in short mode")
+	}
+
 	r := basicResult
 
 	tmp := path.Join(os.TempDir(), "vsolvtest")

--- a/selection.go
+++ b/selection.go
@@ -34,7 +34,7 @@ func (s *selection) getConstraint(id ProjectIdentifier) Constraint {
 	// Start with the open set
 	var ret Constraint = any
 	for _, dep := range deps {
-		ret = ret.Intersect(dep.Dep.Constraint)
+		ret = s.sm.intersect(id, ret, dep.Dep.Constraint)
 	}
 
 	return ret

--- a/selection.go
+++ b/selection.go
@@ -3,6 +3,7 @@ package vsolver
 type selection struct {
 	projects []ProjectAtom
 	deps     map[ProjectIdentifier][]Dependency
+	sm       *smAdapter
 }
 
 func (s *selection) getDependenciesOn(id ProjectIdentifier) []Dependency {

--- a/sm_adapter.go
+++ b/sm_adapter.go
@@ -311,22 +311,18 @@ func (c *smAdapter) vtypeUnion(id ProjectIdentifier, v Version) versionTypeUnion
 
 type versionTypeUnion []Version
 
-// This should generally not be called, but just in case
+// This should generally not be called, but is required for the interface. If it
+// is called, we have a bigger problem (the type has escaped the solver); thus,
+// panic.
 func (av versionTypeUnion) String() string {
-	if len(av) > 0 {
-		return av[0].String()
-	}
-
-	return ""
+	panic("versionTypeUnion should never be turned into a string; it is solver internal-only")
 }
 
-// This should generally not be called, but just in case
+// This should generally not be called, but is required for the interface. If it
+// is called, we have a bigger problem (the type has escaped the solver); thus,
+// panic.
 func (av versionTypeUnion) Type() string {
-	if len(av) > 0 {
-		return av[0].Type()
-	}
-
-	return ""
+	panic("versionTypeUnion should never need to answer a Type() call; it is solver internal-only")
 }
 
 func (av versionTypeUnion) Matches(v Version) bool {

--- a/sm_adapter.go
+++ b/sm_adapter.go
@@ -13,6 +13,10 @@ import "sort"
 // the complexities of deciding what a particular name "means" entirely within
 // the solver, while the SourceManager can traffic exclusively in
 // globally-unique network names.
+//
+// Finally, it provides authoritative version/constraint operations, ensuring
+// that any possible approach to a match - even those not literally encoded in
+// the inputs - is achieved.
 type smAdapter struct {
 	// The underlying, adapted-to SourceManager
 	sm SourceManager
@@ -107,6 +111,116 @@ func (c *smAdapter) pairRevision(id ProjectIdentifier, r Revision) []Version {
 	}
 
 	return p
+}
+
+// matches performs a typical match check between the provided version and
+// constraint. If that basic check fails and the provided version is incomplete
+// (e.g. an unpaired version or bare revision), it will attempt to gather more
+// information on one or the other and re-perform the comparison.
+func (c *smAdapter) matches(id ProjectIdentifier, c2 Constraint, v Version) bool {
+	if c2.Matches(v) {
+		return true
+	}
+
+	// There's a wide field of possible ways that pairing might result in a
+	// match. For each possible type of version, start by carving out all the
+	// cases where the constraint would have provided an authoritative match
+	// result.
+	switch tv := v.(type) {
+	case PairedVersion:
+		switch tc := c2.(type) {
+		case PairedVersion, Revision, noneConstraint:
+			// These three would all have been authoritative matches
+			return false
+		case UnpairedVersion:
+			// Only way paired and unpaired could match is if they share an
+			// underlying rev
+			pv := c.pairVersion(id, tc)
+			if pv == nil {
+				return false
+			}
+			return pv.Matches(v)
+		case semverConstraint:
+			// Have to check all the possible versions for that rev to see if
+			// any match the semver constraint
+			for _, pv := range c.pairRevision(id, tv.Underlying()) {
+				if tc.Matches(pv) {
+					return true
+				}
+			}
+			return false
+		}
+
+	case Revision:
+		switch tc := c2.(type) {
+		case PairedVersion, Revision, noneConstraint:
+			// These three would all have been authoritative matches
+			return false
+		case UnpairedVersion:
+			// Only way paired and unpaired could match is if they share an
+			// underlying rev
+			pv := c.pairVersion(id, tc)
+			if pv == nil {
+				return false
+			}
+			return pv.Matches(v)
+		case semverConstraint:
+			// Have to check all the possible versions for the rev to see if
+			// any match the semver constraint
+			for _, pv := range c.pairRevision(id, tv) {
+				if tc.Matches(pv) {
+					return true
+				}
+			}
+			return false
+		}
+
+	// UnpairedVersion as input has the most weird cases. It's also the one
+	// we'll probably see the least
+	case UnpairedVersion:
+		switch tc := c2.(type) {
+		case noneConstraint:
+			// obviously
+			return false
+		case Revision, PairedVersion:
+			// Easy case for both - just pair the uv and see if it matches the revision
+			// constraint
+			pv := c.pairVersion(id, tv)
+			if pv == nil {
+				return false
+			}
+			return tc.Matches(pv)
+		case UnpairedVersion:
+			// Both are unpaired versions. See if they share an underlying rev.
+			pv := c.pairVersion(id, tv)
+			if pv == nil {
+				return false
+			}
+
+			pc := c.pairVersion(id, tc)
+			if pc == nil {
+				return false
+			}
+			return pc.Matches(pv)
+
+		case semverConstraint:
+			// semverConstraint can't ever match a rev, but we do need to check
+			// if any other versions corresponding to this rev work.
+			pv := c.pairVersion(id, tv)
+			if pv == nil {
+				return false
+			}
+
+			for _, ttv := range c.pairRevision(id, pv.Underlying()) {
+				if c2.Matches(ttv) {
+					return true
+				}
+			}
+			return false
+		}
+	default:
+		panic("unreachable")
+	}
 }
 
 type upgradeVersionSorter []Version

--- a/solve_test.go
+++ b/solve_test.go
@@ -1,6 +1,7 @@
 package vsolver
 
 import (
+	"flag"
 	"fmt"
 	"log"
 	"os"
@@ -8,17 +9,23 @@ import (
 	"testing"
 )
 
+var fixtorun string
+
 // TODO regression test ensuring that locks with only revs for projects don't cause errors
+func init() {
+	flag.StringVar(&fixtorun, "vsolver.fix", "", "A single fixture to run in TestBasicSolves")
+}
 
 var stderrlog = log.New(os.Stderr, "", 0)
 
 func TestBasicSolves(t *testing.T) {
-	//solveAndBasicChecks(fixtures[8], t)
 	for _, fix := range fixtures {
-		solveAndBasicChecks(fix, t)
-		if testing.Verbose() {
-			// insert a line break between tests
-			stderrlog.Println("")
+		if fixtorun == "" || fixtorun == fix.n {
+			solveAndBasicChecks(fix, t)
+			if testing.Verbose() {
+				// insert a line break between tests
+				stderrlog.Println("")
+			}
 		}
 	}
 }
@@ -57,10 +64,10 @@ func fixtureSolveBasicChecks(fix fixture, res Result, err error, t *testing.T) (
 
 		switch fail := err.(type) {
 		case *BadOptsFailure:
-			t.Error("Unexpected bad opts failure solve error: %s", err)
+			t.Error("(fixture: %q) Unexpected bad opts failure solve error: %s", fix.n, err)
 		case *noVersionError:
 			if fix.errp[0] != string(fail.pn.LocalName) { // TODO identifierify
-				t.Errorf("Expected failure on project %s, but was on project %s", fail.pn.LocalName, fix.errp[0])
+				t.Errorf("(fixture: %q) Expected failure on project %s, but was on project %s", fix.n, fail.pn.LocalName, fix.errp[0])
 			}
 
 			ep := make(map[string]struct{})
@@ -83,7 +90,7 @@ func fixtureSolveBasicChecks(fix fixture, res Result, err error, t *testing.T) (
 				}
 			}
 			if len(extra) > 0 {
-				t.Errorf("Expected solve failures due to projects %s, but solve failures also arose from %s", strings.Join(fix.errp[1:], ", "), strings.Join(extra, ", "))
+				t.Errorf("(fixture: %q) Expected solve failures due to projects %s, but solve failures also arose from %s", fix.n, strings.Join(fix.errp[1:], ", "), strings.Join(extra, ", "))
 			}
 
 			for p, _ := range ep {
@@ -92,7 +99,7 @@ func fixtureSolveBasicChecks(fix fixture, res Result, err error, t *testing.T) (
 				}
 			}
 			if len(missing) > 0 {
-				t.Errorf("Expected solve failures due to projects %s, but %s had no failures", strings.Join(fix.errp[1:], ", "), strings.Join(missing, ", "))
+				t.Errorf("(fixture: %q) Expected solve failures due to projects %s, but %s had no failures", fix.n, strings.Join(fix.errp[1:], ", "), strings.Join(missing, ", "))
 			}
 
 		default:

--- a/solver.go
+++ b/solver.go
@@ -165,6 +165,7 @@ func (s *solver) Solve(opts SolveOpts) (Result, error) {
 	// Initialize queues
 	s.sel = &selection{
 		deps: make(map[ProjectIdentifier][]Dependency),
+		sm:   s.sm,
 	}
 	s.unsel = &unselected{
 		sl:  make([]ProjectIdentifier, 0),

--- a/version.go
+++ b/version.go
@@ -383,6 +383,8 @@ func (v versionPair) Underlying() Revision {
 
 func (v versionPair) Matches(v2 Version) bool {
 	switch tv2 := v2.(type) {
+	case versionTypeUnion:
+		return tv2.Matches(v)
 	case versionPair:
 		return v.r == tv2.r
 	case Revision:
@@ -419,6 +421,8 @@ func (v versionPair) Intersect(c2 Constraint) Constraint {
 		return v
 	case noneConstraint:
 		return none
+	case versionTypeUnion:
+		return tc.Intersect(v)
 	case versionPair:
 		if v.r == tc.r {
 			return v.r

--- a/version.go
+++ b/version.go
@@ -88,6 +88,8 @@ func (r Revision) Type() string {
 // version is the same Revision as itself.
 func (r Revision) Matches(v Version) bool {
 	switch tv := v.(type) {
+	case versionTypeUnion:
+		return tv.Matches(r)
 	case Revision:
 		return r == tv
 	case versionPair:
@@ -105,6 +107,8 @@ func (r Revision) MatchesAny(c Constraint) bool {
 		return true
 	case noneConstraint:
 		return false
+	case versionTypeUnion:
+		return tc.MatchesAny(r)
 	case Revision:
 		return r == tc
 	case versionPair:
@@ -120,6 +124,8 @@ func (r Revision) Intersect(c Constraint) Constraint {
 		return r
 	case noneConstraint:
 		return none
+	case versionTypeUnion:
+		return tc.Intersect(r)
 	case Revision:
 		if r == tc {
 			return r
@@ -145,6 +151,8 @@ func (r branchVersion) Type() string {
 
 func (v branchVersion) Matches(v2 Version) bool {
 	switch tv := v2.(type) {
+	case versionTypeUnion:
+		return tv.Matches(v)
 	case branchVersion:
 		return v == tv
 	case versionPair:
@@ -161,6 +169,8 @@ func (v branchVersion) MatchesAny(c Constraint) bool {
 		return true
 	case noneConstraint:
 		return false
+	case versionTypeUnion:
+		return tc.MatchesAny(v)
 	case branchVersion:
 		return v == tc
 	case versionPair:
@@ -178,6 +188,8 @@ func (v branchVersion) Intersect(c Constraint) Constraint {
 		return v
 	case noneConstraint:
 		return none
+	case versionTypeUnion:
+		return tc.Intersect(v)
 	case branchVersion:
 		if v == tc {
 			return v
@@ -212,6 +224,8 @@ func (r plainVersion) Type() string {
 
 func (v plainVersion) Matches(v2 Version) bool {
 	switch tv := v2.(type) {
+	case versionTypeUnion:
+		return tv.Matches(v)
 	case plainVersion:
 		return v == tv
 	case versionPair:
@@ -228,6 +242,8 @@ func (v plainVersion) MatchesAny(c Constraint) bool {
 		return true
 	case noneConstraint:
 		return false
+	case versionTypeUnion:
+		return tc.MatchesAny(v)
 	case plainVersion:
 		return v == tc
 	case versionPair:
@@ -245,6 +261,8 @@ func (v plainVersion) Intersect(c Constraint) Constraint {
 		return v
 	case noneConstraint:
 		return none
+	case versionTypeUnion:
+		return tc.Intersect(v)
 	case plainVersion:
 		if v == tc {
 			return v
@@ -281,6 +299,8 @@ func (r semVersion) Type() string {
 
 func (v semVersion) Matches(v2 Version) bool {
 	switch tv := v2.(type) {
+	case versionTypeUnion:
+		return tv.Matches(v)
 	case semVersion:
 		return v.sv.Equal(tv.sv)
 	case versionPair:
@@ -297,6 +317,8 @@ func (v semVersion) MatchesAny(c Constraint) bool {
 		return true
 	case noneConstraint:
 		return false
+	case versionTypeUnion:
+		return tc.MatchesAny(v)
 	case semVersion:
 		return v.sv.Equal(tc.sv)
 	case versionPair:
@@ -314,6 +336,8 @@ func (v semVersion) Intersect(c Constraint) Constraint {
 		return v
 	case noneConstraint:
 		return none
+	case versionTypeUnion:
+		return tc.Intersect(v)
 	case semVersion:
 		if v.sv.Equal(tc.sv) {
 			return v


### PR DESCRIPTION
Initially I'd thought this one could be pushed off, but turns out...not so much. It becomes necessary exactly as soon as you've got locked revs (and only revs) coming out of a manifest. We have to assume that'll regularly be the case.

This introduces an apparatus for 'authoritative' constraint ops - that is, if the typical `Matches()`, `MatchesAny()`, or `Intersect()` method fails/returns `none`, the solver - specifically, the `smAdapter` - will reach out to the source manager and find any 'synonyms' for both operands, retry the operation.

Initially, I was handling the cases for this manually. It was easy enough for `Matches()`, but it got nuts for the other two. So, I made `versionTypeUnion` - a union that ORs together a bunch of versions, and itself implements a version. It's *strictly* not supposed to be exposed externally, so it panics if its public-y methods (`String()` and `Type()`) are called, but it seems to be OK for internal use.

...that said, this version system is starting to make me really uncomfortable. If it has to grow again, it might be worth seriously refactoring - even if only to collapse `plainVersion`, `semVersion`, and `branchVersion` down into a single type with a flag to differentiate. Too many things are getting encoded into too paltry of a type system; the switches are getting ridiculous, particularly because different switch branches may represent significantly different intentions and guarantees.