### PR TITLE
Alternate approaches to populating a version queue

### DIFF
--- a/bridge.go
+++ b/bridge.go
@@ -59,7 +59,7 @@ type bridge struct {
 		err   error
 	}
 
-	// A map of packages to ignore.
+	// A map of packages to ignore
 	ignore map[string]bool
 
 	// Map of project root name to their available version list. This cache is

--- a/selection.go
+++ b/selection.go
@@ -141,8 +141,6 @@ func (s *selection) selected(id ProjectIdentifier) (atomWithPackages, bool) {
 	return atomWithPackages{a: nilpa}, false
 }
 
-// TODO take a ProjectName, but optionally also a preferred version. This will
-// enable the lock files of dependencies to remain slightly more stable.
 type unselected struct {
 	sl  []bimodalIdentifier
 	cmp func(i, j int) bool
@@ -179,7 +177,6 @@ func (u *unselected) Pop() (v interface{}) {
 // The worst case for both of these is O(n), but in practice the first case is
 // be O(1), as we iterate the queue from front to back.
 func (u *unselected) remove(bmi bimodalIdentifier) {
-	// TODO is it worth implementing a binary search here?
 	for k, pi := range u.sl {
 		if pi.id.eq(bmi.id) {
 			// Simple slice comparison - assume they're both sorted the same

--- a/solve_bimodal_test.go
+++ b/solve_bimodal_test.go
@@ -388,16 +388,85 @@ var bimodalFixtures = map[string]bimodalFixture{
 		),
 	},
 	// Preferred version, as derived from a dep's lock, is attempted first
-	// TODO
-
+	"respect prefv, simple case": {
+		ds: []depspec{
+			dsp(dsv("root 0.0.0"),
+				pkg("root", "a")),
+			dsp(dsv("a 1.0.0"),
+				pkg("a", "b")),
+			dsp(dsv("b 1.0.0 foorev"),
+				pkg("b")),
+			dsp(dsv("b 2.0.0 barrev"),
+				pkg("b")),
+		},
+		lm: map[string]fixLock{
+			"a 1.0.0": mklock(
+				"b 1.0.0 foorev",
+			),
+		},
+		r: mkresults(
+			"a 1.0.0",
+			"b 1.0.0 foorev",
+		),
+	},
 	// Preferred version, as derived from a dep's lock, is attempted first, even
 	// if the root also has a direct dep on it (root doesn't need to use
-	// preferreds, because it has direct control)
-	// TODO
+	// preferreds, because it has direct control AND because the root lock
+	// already supercedes dep lock "preferences")
+	"respect dep prefv with root import": {
+		ds: []depspec{
+			dsp(dsv("root 0.0.0"),
+				pkg("root", "a", "b")),
+			dsp(dsv("a 1.0.0"),
+				pkg("a", "b")),
+			//dsp(dsv("a 1.0.1"),
+			//pkg("a", "b")),
+			//dsp(dsv("a 1.1.0"),
+			//pkg("a", "b")),
+			dsp(dsv("b 1.0.0 foorev"),
+				pkg("b")),
+			dsp(dsv("b 2.0.0 barrev"),
+				pkg("b")),
+		},
+		lm: map[string]fixLock{
+			"a 1.0.0": mklock(
+				"b 1.0.0 foorev",
+			),
+		},
+		r: mkresults(
+			"a 1.0.0",
+			"b 1.0.0 foorev",
+		),
+	},
 
 	// Preferred versions can only work if the thing offering it has been
 	// selected, or at least marked in the unselected queue
-	// TODO
+	"prefv only works if depper is selected": {
+		ds: []depspec{
+			dsp(dsv("root 0.0.0"),
+				pkg("root", "a", "b")),
+			// Three atoms for a, which will mean it gets visited after b
+			dsp(dsv("a 1.0.0"),
+				pkg("a", "b")),
+			dsp(dsv("a 1.0.1"),
+				pkg("a", "b")),
+			dsp(dsv("a 1.1.0"),
+				pkg("a", "b")),
+			dsp(dsv("b 1.0.0 foorev"),
+				pkg("b")),
+			dsp(dsv("b 2.0.0 barrev"),
+				pkg("b")),
+		},
+		lm: map[string]fixLock{
+			"a 1.0.0": mklock(
+				"b 1.0.0 foorev",
+			),
+		},
+		r: mkresults(
+			"a 1.1.0",
+			"b 2.0.0 barrev",
+		),
+	},
 
 	// Revision enters vqueue if a dep has a constraint on that revision
 	// TODO

--- a/solve_test.go
+++ b/solve_test.go
@@ -113,7 +113,7 @@ func solveBimodalAndCheck(fix bimodalFixture, t *testing.T) (res Result, err err
 	if testing.Verbose() {
 		stderrlog.Printf("[[fixture %q]]", fix.n)
 	}
-	sm := newbmSM(fix.ds, fix.ignore)
+	sm := newbmSM(fix)
 
 	args := SolveArgs{
 		Root:     string(fix.ds[0].Name()),

--- a/solver.go
+++ b/solver.go
@@ -870,16 +870,6 @@ func (s *solver) unselectedComparator(i, j int) bool {
 		return false
 	}
 
-	rname := s.rm.Name()
-	// *always* put root project first
-	// TODO wait, it shouldn't be possible to have root in here...?
-	if iname.LocalName == rname {
-		return true
-	}
-	if jname.LocalName == rname {
-		return false
-	}
-
 	_, ilock := s.rlm[iname]
 	_, jlock := s.rlm[jname]
 

--- a/solver.go
+++ b/solver.go
@@ -584,7 +584,7 @@ func (s *solver) createVersionQueue(bmi bimodalIdentifier) (*versionQueue, error
 	id := bmi.id
 	// If on the root package, there's no queue to make
 	if id.LocalName == s.rm.Name() {
-		return newVersionQueue(id, nilpa, s.b)
+		return newVersionQueue(id, nil, nil, s.b)
 	}
 
 	exists, err := s.b.repoExists(id)
@@ -614,7 +614,7 @@ func (s *solver) createVersionQueue(bmi bimodalIdentifier) (*versionQueue, error
 		}
 	}
 
-	q, err := newVersionQueue(id, lockv, s.b)
+	q, err := newVersionQueue(id, lockv, nil, s.b)
 	if err != nil {
 		// TODO this particular err case needs to be improved to be ONLY for cases
 		// where there's absolutely nothing findable about a given project name

--- a/solver.go
+++ b/solver.go
@@ -614,7 +614,17 @@ func (s *solver) createVersionQueue(bmi bimodalIdentifier) (*versionQueue, error
 		}
 	}
 
-	q, err := newVersionQueue(id, lockv, nil, s.b)
+	var prefv Version
+	if bmi.fromRoot {
+		// If this bmi came from the root, then we want to search the unselected
+		// queue to see if anything *else* wants this ident, in which case we
+		// pick up that prefv
+	} else {
+		// Otherwise, just use the preferred version expressed in the bmi
+		prefv = bmi.prefv
+	}
+
+	q, err := newVersionQueue(id, lockv, prefv, s.b)
 	if err != nil {
 		// TODO this particular err case needs to be improved to be ONLY for cases
 		// where there's absolutely nothing findable about a given project name

--- a/types.go
+++ b/types.go
@@ -57,9 +57,17 @@ func (i ProjectIdentifier) normalize() ProjectIdentifier {
 }
 
 // bimodalIdentifiers are used to track work to be done in the unselected queue.
+// TODO marker for root, to know to ignore prefv...or can we do unselected queue
+// sorting only?
 type bimodalIdentifier struct {
 	id ProjectIdentifier
+	// List of packages required within/under the ProjectIdentifier
 	pl []string
+	// prefv is used to indicate a 'preferred' version. This is expected to be
+	// derived from a dep's lock data, or else is empty.
+	prefv Version
+	// Indicates that the bmi came from the root project originally
+	fromRoot bool
 }
 
 type ProjectName string


### PR DESCRIPTION
This adds support for some alternate means by which the version queue gets its versions. It encompasses #49 and #16, which are mostly urelated, except that they both required the same basic refactoring to `*versionQueue* itself in order to gracefully handle more than a single injected item (previously, the root lock version) at the front of the queue.